### PR TITLE
JGI like ID symbols fix

### DIFF
--- a/FASTSTEP3R
+++ b/FASTSTEP3R
@@ -63,14 +63,14 @@ cat(paste0("Importing and indexing files needed... | ", date(), "\n"))
 
 ## Import tmp_gene_list
 
-tmp.genelist <- fread(paste0(opt$tmp,"/tmp_gene_list"),header = F)
+tmp.genelist <- fread(paste0(opt$tmp,"/tmp_gene_list"), header = F, sep = "\t")
 
 ## Import ${DIAMONDOUT} splitted files and indexing for fast queries
 
 Diamond.results <- list()
 Split.files <- paste0(opt$tmp,"/",list.files(opt$tmp)[grep(opt$pattern, list.files(opt$tmp))]) 
 for(i in 1:length(Split.files)){
-    Diamond.results[[i]] <- fread(Split.files[i], header = F)
+    Diamond.results[[i]] <- fread(Split.files[i], header = F, sep = "\t")
     setkey(Diamond.results[[i]], V1, verbose = FALSE)
 }
 


### PR DESCRIPTION
Dear @josuebarrera,

This small change should fix the weird behaviour of FASTSTEP3R with JGI like GeneIDs (which usually contain "|" symbols).

**ISSUE**

https://github.com/josuebarrera/GenEra/issues/18

**PROBLEM:**

Data.table as default sep try to maximize the number of lines so the package uses a bunch of different symbols which include |. 

**SOLUTION:**

Now in the the modified FASTSTEP3R "\t" sep is specified for reading $DIAMONDOUT and tmp_genelist. I have tested this with 5 proteomes in JGI and it seems that it is working fine. 

I hope that this small change could be helpful and if you find any issues, i will be completely available so let me know! 👨‍💻

Cheers,

Víctor

